### PR TITLE
target Java 8 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 version = getVersionFromDescriptionProps()
 
 sourceCompatibility = 1.11
-targetCompatibility = 1.11
+targetCompatibility = 1.8
 compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"
 


### PR DESCRIPTION
Weka still supports Java 8, so change the target version to 1.8.
Fixes #29.